### PR TITLE
Fixed building dbscan

### DIFF
--- a/dbscan.cu
+++ b/dbscan.cu
@@ -6,6 +6,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/sort.h>
+#include <thrust/count.h>
+#include <thrust/unique.h>
 #include <time.h>
 
 #include <algorithm>


### PR DESCRIPTION
thrust changed namespace hierarchy

```sh
 make && ./main.exe ./test-datasets/2d.txt
```
works again on my device.